### PR TITLE
iOS12以上でもタップ可能にする

### DIFF
--- a/IntSlider/IntSlider.swift
+++ b/IntSlider/IntSlider.swift
@@ -30,6 +30,12 @@ final class IntSlider: UISlider {
     
     override func beginTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
         // つまみ部分以外でもスライド可能
+        let point = touch.location(in: self)
+        let fraction = point.x / bounds.width
+        let newValue = (maximumValue - minimumValue) * Float(fraction) + minimumValue
+        if newValue != value {
+            value = newValue
+        }
         return true
     }
     


### PR DESCRIPTION
### 参考
- [UISliderをタップで選択可能にする (iOS12以上の場合)](https://qiita.com/n_komiya/items/15d3d755e2bed46b5da2)
